### PR TITLE
Remove unneeded polyfill for setImmediate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ val versions = new {
 lazy val scalaJsMacrotaskExecutor = Seq(
   // https://github.com/scala-js/scala-js-macrotask-executor
   libraryDependencies       += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0",
-  Compile / npmDependencies += "setimmediate"  -> "1.0.5", // polyfill
 )
 
 lazy val webapp = (project in file("webapp"))


### PR DESCRIPTION
The MacroTaskExecutor already contains the setImmediate polyfill.